### PR TITLE
Add automated flake8 testing of pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: python
+cache: pip
+python:
+    - 2.7
+    - 3.6
+matrix:
+    allow_failures:
+        - python: 3.6
+install:
+    - pip install flake8
+before_script:
+    # stop the build if there are Python syntax errors or undefined names
+    - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+    - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script:
+    - true
+notifications:
+    on_success: change
+    on_failure: change  # `always` will be the setting once code changes slow down


### PR DESCRIPTION
The Travis Continuous Integration service is free for all open source projects like this one. This configuration will enable Travis CI to run tests on all pull requests before they are merged. The owner of this repo would need to go to https://travis-ci.org/profile (log in via GitHub) and flip the repository switch on to enable free, automated flake8 testing of each pull request. Travis CI will run tests in parallel on both Python 2 and Python 3 but until the port can be completed, the Python 3 test should continue to be run in allow_failures mode.