### PR TITLE
Fix import errors in matchzoo/models/knrm.py

### DIFF
--- a/matchzoo/models/knrm.py
+++ b/matchzoo/models/knrm.py
@@ -1,12 +1,14 @@
 # -*- coding=utf-8 -*-
 from __future__ import print_function
 from __future__ import absolute_import
+from keras.models import Model
 from keras.optimizers import Adam
-from keras.initializers import Constant, RandomNormal
 from keras.constraints import maxnorm, unitnorm, non_neg, min_max_norm, non_neg
 from keras.regularizers import l2, l1
 from keras.layers import Input, Embedding, Dense, Activation, Lambda, Dot
 from keras.activations import softmax
+from keras import initializers
+from keras import backend as K
 from model import BasicModel
 from utils.utility import *
 


### PR DESCRIPTION
Thanks for making MatchZoo !

I was running one of the examples:

python matchzoo/main.py --phase train --model_file examples/toy_example/config/knrm_ranking.config

That example failed because of import errors in matchzoo/models/knrm.py

I fixed the import errors in this PR - then the example works properly