### PR TITLE
remove resouce package (os denpendent), use psutil

### DIFF
--- a/matchzoo/utils/utility.py
+++ b/matchzoo/utils/utility.py
@@ -2,7 +2,7 @@
 import os
 import sys
 import traceback
-import resource
+import psutil
 
 
 def show_layer_info(layer_name, layer_out):
@@ -10,13 +10,8 @@ def show_layer_info(layer_name, layer_out):
 
 
 def show_memory_use():
-    rusage_denom = 1024.
-    if sys.platform == 'darwin':
-        rusage_denom = rusage_denom * rusage_denom
-    ru = resource.getrusage(resource.RUSAGE_SELF)
-    total_memory = 1. * (ru.ru_maxrss + ru.ru_ixrss + ru.ru_idrss + ru.ru_isrss) / rusage_denom
-    strinfo = "\x1b[33m [Memory] Total Memory Use: %.4f MB \t Resident: %ld Shared: %ld UnshareData: %ld UnshareStack: %ld \x1b[0m" % \
-        (total_memory, ru.ru_maxrss, ru.ru_ixrss, ru.ru_idrss, ru.ru_isrss)
+    used_memory_percent = psutil.virtual_memory().percent
+    strinfo = '{}% memory has been used'.format(used_memory_percent)
     return strinfo
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ pytest-cov >= 2.4.0
 mock >= 2.0.0
 flake8 >= 3.2.1
 flake8_docstrings >= 1.0.2
+psutil>=5.4.6

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,8 @@ setup(
         'h5py >= 2.7.0',
         'tqdm >= 4.19.4',
         'scipy >= 1.0.0',
-        'jieba >= 0.39'
+        'jieba >= 0.39',
+        'psutil >= 5.4.6'
     ],
     extras_require={
         'visualize': ['matplotlib >= 2.2.0'],


### PR DESCRIPTION
For issue #30 #182 

1. Remove `resource` package since it's dependent on linux.
2. Use `psutil` package for memory usage calculation.
3. Add `psutil` to `requirements.txt` and `setup.py`.