### PR TITLE
Refactor output layer

### DIFF
--- a/matchzoo/engine/base_model.py
+++ b/matchzoo/engine/base_model.py
@@ -9,6 +9,7 @@ import numpy as np
 import keras
 
 from matchzoo import engine
+from matchzoo import tasks
 
 
 class BaseModel(abc.ABC):
@@ -226,6 +227,14 @@ class BaseModel(abc.ABC):
 
         if self._params['optimizer'] is None:
             self._params['optimizer'] = 'adam'
+
+    def _make_output_layer(self):
+        """:return: a correctly shaped keras dense layer for model output."""
+        task = self._params['task']
+        if isinstance(task, tasks.Classification):
+            return keras.layers.Dense(task.num_classes, activation='softmax')
+        elif isinstance(task, tasks.Ranking):
+            return keras.layers.Dense(1, activation='sigmoid')
 
 
 def load_model(dirpath: typing.Union[str, Path]) -> BaseModel:

--- a/matchzoo/engine/base_model.py
+++ b/matchzoo/engine/base_model.py
@@ -16,7 +16,7 @@ class BaseModel(abc.ABC):
     """Abstract base class of all matchzoo models."""
 
     BACKEND_FILENAME = 'backend.h5'
-    PARAMS_FILENAME = 'params.pkl'
+    PARAMS_FILENAME = 'params.dill'
 
     def __init__(
             self,

--- a/matchzoo/engine/base_model.py
+++ b/matchzoo/engine/base_model.py
@@ -235,6 +235,8 @@ class BaseModel(abc.ABC):
             return keras.layers.Dense(task.num_classes, activation='softmax')
         elif isinstance(task, tasks.Ranking):
             return keras.layers.Dense(1, activation='sigmoid')
+        else:
+            raise ValueError("Invalid task type.")
 
 
 def load_model(dirpath: typing.Union[str, Path]) -> BaseModel:

--- a/matchzoo/engine/base_task.py
+++ b/matchzoo/engine/base_task.py
@@ -3,8 +3,6 @@
 import typing
 import abc
 
-import keras
-
 
 class BaseTask(abc.ABC):
     """Base Task, shouldn't be used directly."""
@@ -18,10 +16,6 @@ class BaseTask(abc.ABC):
     @abc.abstractmethod
     def list_available_metrics(cls) -> list:
         """:return: a list of available metrics."""
-
-    @abc.abstractmethod
-    def make_output_layer(self) -> keras.layers.Dense:
-        """:return: a keras layer to match the task."""
 
     @property
     @abc.abstractmethod

--- a/matchzoo/models/dense_baseline_model.py
+++ b/matchzoo/models/dense_baseline_model.py
@@ -38,5 +38,5 @@ class DenseBaselineModel(engine.BaseModel):
         x = keras.layers.concatenate(x_in)
         x = keras.layers.Dense(
                 self._params['num_dense_units'], activation='relu')(x)
-        x_out = self.params['task'].make_output_layer()(x)
+        x_out = self._make_output_layer()(x)
         self._backend = keras.models.Model(inputs=x_in, outputs=x_out)

--- a/matchzoo/models/naive_model.py
+++ b/matchzoo/models/naive_model.py
@@ -13,5 +13,5 @@ class NaiveModel(engine.BaseModel):
         x_in = [keras.layers.Input(shape)
                 for shape in self._params['input_shapes']]
         x = keras.layers.concatenate(x_in)
-        x_out = self._params['task'].make_output_layer()(x)
+        x_out = self._make_output_layer()(x)
         self._backend = keras.models.Model(inputs=x_in, outputs=x_out)

--- a/matchzoo/tasks/classification.py
+++ b/matchzoo/tasks/classification.py
@@ -1,7 +1,5 @@
 """Classification task."""
 
-import keras
-
 from matchzoo import engine
 
 
@@ -31,10 +29,6 @@ class Classification(engine.BaseTask):
     def list_available_metrics(cls) -> list:
         """:return: a list of available metrics."""
         return ['acc']
-
-    def make_output_layer(self) -> keras.layers.Dense:
-        """:return: a correctly shaped keras dense layer for model output."""
-        return keras.layers.Dense(self._num_classes, activation='softmax')
 
     @property
     def output_shape(self) -> tuple:

--- a/matchzoo/tasks/ranking.py
+++ b/matchzoo/tasks/ranking.py
@@ -1,7 +1,5 @@
 """Ranking task."""
 
-import keras
-
 from matchzoo import engine
 
 
@@ -17,10 +15,6 @@ class Ranking(engine.BaseTask):
     def list_available_metrics(cls) -> list:
         """:return: a list of available metrics."""
         return ['mae']
-
-    def make_output_layer(self):
-        """:return: a correctly shaped keras dense layer for model output."""
-        return keras.layers.Dense(1, activation='sigmoid')
 
     @property
     def output_shape(self) -> tuple:

--- a/tests/unit_test/tasks/test_tasks.py
+++ b/tests/unit_test/tasks/test_tasks.py
@@ -29,10 +29,3 @@ def test_classification_num_classes(arg):
 
 def test_list_available_tasks():
     assert tasks.list_available_task_types()
-
-
-@pytest.mark.parametrize("task_type", [
-    tasks.Ranking, tasks.Classification
-])
-def test_make_output_layers(task_type):
-    assert task_type().make_output_layer()


### PR DESCRIPTION
Refactor `tasks.BaseTask.make_output_layer` into `engine.BaseModel._make_output_layer`, so models can customize their output layers based on different task by overriding the default behavior.