### PR TITLE
Fix a possible bug in rank_io read_data

### DIFF
--- a/matchzoo/utils/rank_io.py
+++ b/matchzoo/utils/rank_io.py
@@ -81,10 +81,10 @@ def read_data(filename, word_dict = None):
         line = line.strip().split()
         tid = line[0]
         if word_dict is None:
-            data[tid] = list(map(int, line[2:]))
+            data[tid] = list(map(int, line[1:]))
         else:
             data[tid] = []
-            for w in line[2:]:
+            for w in line[1:]:
                 if w not in word_dict:
                     word_dict[w] = len(word_dict)
                 data[tid].append(word_dict[w])


### PR DESCRIPTION
line is from corpus_preprocessed, which is DocumentID followed by wordIDs
I suppose line[2:] should be changed to line[1:]? Otherwise the first word is dropped.
Feel free to correct me if I'm wrong.