### PR TITLE
remove context property from base preprocessor to make it stateless

### DIFF
--- a/matchzoo/engine/base_preprocessor.py
+++ b/matchzoo/engine/base_preprocessor.py
@@ -14,24 +14,6 @@ class BasePreprocessor(metaclass=abc.ABCMeta):
 
     DATA_FILENAME = 'preprocessor.dill'
 
-    def __init__(self, context={}):
-        """Initialization."""
-        self._context = context
-
-    @property
-    def context(self):
-        """Get fitted parameters."""
-        return self._context
-
-    @context.setter
-    def context(self, context: dict):
-        """
-        Set pre-fitted context.
-
-        :param context: pre-fitted context.
-        """
-        self._context = context
-
     @abc.abstractmethod
     def fit(self, inputs: list) -> 'BasePreprocessor':
         """

--- a/matchzoo/preprocessor/dssm_preprocessor.py
+++ b/matchzoo/preprocessor/dssm_preprocessor.py
@@ -27,18 +27,13 @@ class DSSMPreprocessor(engine.BasePreprocessor):
         >>> rv_train = dssm_preprocessor.fit_transform(
         ...     train_inputs,
         ...     stage='train')
-        >>> dssm_preprocessor.context['input_shapes'][0][0]
-        37
         >>> type(rv_train)
         <class 'matchzoo.datapack.DataPack'>
-        >>> context = dssm_preprocessor.context
-        >>> dssm_preprocessor_test = DSSMPreprocessor()
-        >>> dssm_preprocessor_test.context = context
         >>> test_inputs = [("id0",
         ...                 "id4",
         ...                 "beijing",
         ...                 "I visted beijing yesterday.")]
-        >>> rv_test = dssm_preprocessor_test.fit_transform(
+        >>> rv_test = dssm_preprocessor.fit_transform(
         ...     test_inputs,
         ...     stage='test')
         >>> type(rv_test)
@@ -51,7 +46,7 @@ class DSSMPreprocessor(engine.BasePreprocessor):
         self._datapack = None
         self._cache_left = []
         self._cache_right = []
-        super().__init__()
+        self._context = {}
 
     def _prepare_stateless_units(self) -> list:
         """Prepare needed process units."""


### PR DESCRIPTION
Remove the `context` property to make `*_processor` stateless.