### PR TITLE
factor out segmentation from base preprocessor into mixin class

### DIFF
--- a/matchzoo/engine/base_preprocessor.py
+++ b/matchzoo/engine/base_preprocessor.py
@@ -2,9 +2,9 @@
 
 import abc
 import typing
-from pathlib import Path
+
 import dill
-import pandas as pd
+from pathlib import Path
 
 from matchzoo import datapack
 
@@ -74,41 +74,6 @@ class BasePreprocessor(metaclass=abc.ABCMeta):
             dirpath.mkdir()
 
         dill.dump(self, open(data_file_path, mode='wb'))
-
-    def segmentation(self, inputs: list, stage: str) -> datapack.DataPack:
-        """
-        Convert user input into :class:`DataPack` consist of two tables.
-
-        :param inputs: Raw user inputs, list of tuples.
-        :param stage: `train` or `test`.
-
-        :return: User input into a :class:`DataPack` with content and
-            relation.
-        """
-        col_all = ['id_left', 'id_right', 'text_left', 'text_right']
-        col_relation = ['id_left', 'id_right']
-
-        if stage == 'train':
-            col_relation.append('label')
-            col_all.append('label')
-
-        # prepare data pack.
-        inputs = pd.DataFrame(inputs, columns=col_all)
-
-        # Segment input into 3 dataframes.
-        relation = inputs[col_relation]
-
-        left = inputs[['id_left', 'text_left']].drop_duplicates(
-            ['id_left'])
-        left.set_index('id_left', inplace=True)
-
-        right = inputs[['id_right', 'text_right']].drop_duplicates(
-            ['id_right'])
-        right.set_index('id_right', inplace=True)
-
-        return datapack.DataPack(relation=relation,
-                                 left=left,
-                                 right=right)
 
 
 def load_preprocessor(dirpath: typing.Union[str, Path]) -> datapack.DataPack:

--- a/matchzoo/preprocessor/__init__.py
+++ b/matchzoo/preprocessor/__init__.py
@@ -13,4 +13,5 @@ from .process_units import (
     SlidingWindowUnit,
     FixedLengthUnit
 )
+from .segment_mixin import SegmentMixin
 from .dssm_preprocessor import DSSMPreprocessor

--- a/matchzoo/preprocessor/dssm_preprocessor.py
+++ b/matchzoo/preprocessor/dssm_preprocessor.py
@@ -11,7 +11,7 @@ from tqdm import tqdm
 logger = logging.getLogger(__name__)
 
 
-class DSSMPreprocessor(engine.BasePreprocessor):
+class DSSMPreprocessor(engine.BasePreprocessor, preprocessor.SegmentMixin):
     """
     DSSM preprocessor helper.
 
@@ -71,7 +71,7 @@ class DSSMPreprocessor(engine.BasePreprocessor):
         logger.info("Start building vocabulary & fitting parameters.")
 
         # Convert user input into a datapack object.
-        self._datapack = self.segmentation(inputs, stage='train')
+        self._datapack = self.segment(inputs, stage='train')
 
         # Loop through user input to generate tri-letters.
         # 1. Used for build vocabulary of tri-letters (get dimension).
@@ -148,7 +148,7 @@ class DSSMPreprocessor(engine.BasePreprocessor):
             # do preprocessing from scrach.
             units = self._prepare_stateless_units()
             units.append(hashing)
-            self._datapack = self.segmentation(inputs, stage='test')
+            self._datapack = self.segment(inputs, stage='test')
 
             left = self._datapack.left
             right = self._datapack.right

--- a/matchzoo/preprocessor/segment_mixin.py
+++ b/matchzoo/preprocessor/segment_mixin.py
@@ -1,0 +1,50 @@
+"""Convert list of input into class:`DataPack` expected format."""
+
+import pandas as pd
+from matchzoo import datapack
+
+
+class SegmentMixin(object):
+    """
+    Convert list of input into :class:`DataPack` expected format.
+
+    This is a Mixin class, use multiple inherientence in Preprocessor
+    classes. The input will be splited into three dataframes, including
+    :attr:`left`, :attr:`right` and :attr:`relation`.
+
+    """
+
+    def segment(self, inputs: list, stage: str) -> datapack.DataPack:
+        """
+        Convert user input into :class:`DataPack` consist of two tables.
+
+        :param inputs: Raw user inputs, list of tuples.
+        :param stage: `train` or `test`.
+
+        :return: User input into a :class:`DataPack` with left, right and
+            relation..
+        """
+        col_all = ['id_left', 'id_right', 'text_left', 'text_right']
+        col_relation = ['id_left', 'id_right']
+
+        if stage == 'train':
+            col_relation.append('label')
+            col_all.append('label')
+
+        # prepare data pack.
+        inputs = pd.DataFrame(inputs, columns=col_all)
+
+        # Segment input into 3 dataframes.
+        relation = inputs[col_relation]
+
+        left = inputs[['id_left', 'text_left']].drop_duplicates(
+            ['id_left'])
+        left.set_index('id_left', inplace=True)
+
+        right = inputs[['id_right', 'text_right']].drop_duplicates(
+            ['id_right'])
+        right.set_index('id_right', inplace=True)
+
+        return datapack.DataPack(relation=relation,
+                                 left=left,
+                                 right=right)


### PR DESCRIPTION
This PR is important.

Put `segmentation` into `base_preprocessor` is a bit wired since the `base_preprocessor` is a high level of abstraction while `segmentation` is much more concrete.

And `segmentation` is required in multiple preprocessors, so I decided to create a Mixin class as an extra-plugin feature that can be added to multiple places using multiple inheritance, and factor out `segmentation` from `base_preprocessor`.

A more detailed description of mixin class can be found [here](https://stackoverflow.com/questions/533631/what-is-a-mixin-and-why-are-they-useful).

It might affect DSSM/CDSSM/Arc-I preprocessor implementations. @pl8787 @ZizhenWang 